### PR TITLE
Enable use of trait secured auth.raml

### DIFF
--- a/rtypes/attachments.raml
+++ b/rtypes/attachments.raml
@@ -5,7 +5,7 @@
 # - searchable: !include traits/searchable.raml
 
     description: Collection of <<resourcePathName|!singularize>> items.
-    is: [language]
+    is: [secured, language]
 
     get:
       description: Get the file content

--- a/rtypes/collection.raml
+++ b/rtypes/collection.raml
@@ -5,7 +5,7 @@
 # - searchable: !include traits/searchable.raml
 
       description: Collection of <<resourcePathName|!singularize>> items.
-      is: [language]
+      is: [secured, language]
 
       get:
         description: Retrieve a list of <<resourcePathName|!singularize>> items.

--- a/rtypes/get-only.raml
+++ b/rtypes/get-only.raml
@@ -1,5 +1,5 @@
       description: Collection of <<resourcePathName|!singularize>> items.
-      is: [language]
+      is: [secured, language]
 
       get:
         description: Retrieve a list of <<resourcePathName|!singularize>> items.

--- a/rtypes/item-collection.raml
+++ b/rtypes/item-collection.raml
@@ -1,6 +1,6 @@
 
     description: Entity representing a <<resourcePathName|!singularize>>
-    is: [language]
+    is: [secured, language]
 
     get:
       description: |

--- a/rtypes/post-empty-body.raml
+++ b/rtypes/post-empty-body.raml
@@ -1,5 +1,5 @@
 
-      is: [language]
+      is: [secured, language]
       post:
         responses:
           201:

--- a/traits/auth.raml
+++ b/traits/auth.raml
@@ -1,21 +1,2 @@
-
-      headers:
-        Authorization:
-          description: |
-            Used to send a valid JWT token.
-          example: |
-            Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ
-          required: true
-      responses:
-        401:
-          description: |
-            No valid token found
-          body:
-            text/plain:
-              example: "Unauthorized"
-        403:
-          description: |
-            Access denied, not valid privilege in resources
-          body:
-            text/plain:
-              example: "Unauthorized"
+# As empty as we can make auth
+headers:

--- a/traits/auth_security.raml
+++ b/traits/auth_security.raml
@@ -1,0 +1,21 @@
+
+      headers:
+        Authorization:
+          description: |
+            Used to send a valid JWT token.
+          example: |
+            Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ
+          required: true
+      responses:
+        401:
+          description: |
+            No valid token found
+          body:
+            text/plain:
+              example: "Unauthorized"
+        403:
+          description: |
+            Access denied, not valid privilege in resources
+          body:
+            text/plain:
+              example: "Unauthorized"


### PR DESCRIPTION
auth.raml is empty. It may be replaced with auth_security.raml
for publishing. Thus auth_security.raml is what USED to be
auth.raml.