### PR TITLE
DMOD-117 Fix payment example

### DIFF
--- a/traits/payment.raml
+++ b/traits/payment.raml
@@ -5,7 +5,7 @@
           enum: [pay, waive, dispute]
           required: true
           default: pay
-          example: pay, waive, dispute
+          example: waive
         amount:
           description: |
             Amount to pay against all current fines on patron


### PR DESCRIPTION
Revealed by eslint in mod-circulation: “value should be one of”