### PR TITLE
FOLIO-573 filename schema key

### DIFF
--- a/ramls/mod-login/login.raml
+++ b/ramls/mod-login/login.raml
@@ -8,12 +8,12 @@ documentation:
     content: This module provides a username/password based login mechanism for FOLIO credentials
 
 schemas:
-  - credentials: !include ../../schemas/mod-login/credentials.json
+  - credentials.json: !include ../../schemas/mod-login/credentials.json
   - credentialsListObject: !include ../../schemas/mod-login/credentialsListObject.json
   - loginCredentials: !include ../../schemas/mod-login/loginCredentials.json
   - errors: !include ../../schemas/errors.schema
-  - error: !include ../../schemas/error.schema
-  - parameters: !include ../../schemas/parameters.schema
+  - error.schema: !include ../../schemas/error.schema
+  - parameters.schema: !include ../../schemas/parameters.schema
 
 traits:
   - validate: !include ../../traits/validation.raml
@@ -123,7 +123,7 @@ traits:
           200:
             body:
               application/json:
-                schema: credentials
+                schema: credentials.json
           404:
             description: "User not found"
             body:

--- a/ramls/mod-permissions/permission_interface.raml
+++ b/ramls/mod-permissions/permission_interface.raml
@@ -8,7 +8,7 @@ documentation:
     content: This API provides a callback point for Okapi when new permission sets are added to the tenant
 
 schemas:
-  - okapiPermission: !include ../../schemas/mod-permissions/okapiPermission.json
+  - okapiPermission.json: !include ../../schemas/mod-permissions/okapiPermission.json
   - okapiPermissionSet: !include ../../schemas/mod-permissions/okapiPermissionSet.json
 
 /_/tenantpermissions:

--- a/ramls/mod-permissions/permissions.raml
+++ b/ramls/mod-permissions/permissions.raml
@@ -8,16 +8,16 @@ documentation:
     content: This module is responsible for managing and retrieving permissions in the FOLIO system
 
 schemas:
-  - permission: !include ../../schemas/mod-permissions/permission.json
+  - permission.json: !include ../../schemas/mod-permissions/permission.json
   - permission-patch: !include ../../schemas/mod-permissions/permission.json
   - permissionNameObject: !include ../../schemas/mod-permissions/permissionNameObject.json
   - permissionListObject: !include ../../schemas/mod-permissions/permissionListObject.json
-  - permissionUser: !include ../../schemas/mod-permissions/permissionUser.json
+  - permissionUser.json: !include ../../schemas/mod-permissions/permissionUser.json
   - permissionUserListObject: !include ../../schemas/mod-permissions/permissionUserListObject.json
   - permissionNameListObject: !include ../../schemas/mod-permissions/permissionNameListObject.json
   - errors: !include ../../schemas/errors.schema
-  - error: !include ../../schemas/error.schema
-  - parameters: !include ../../schemas/parameters.schema
+  - error.schema: !include ../../schemas/error.schema
+  - parameters.schema: !include ../../schemas/parameters.schema
 
 traits:
   - validate: !include ../../traits/validation.raml
@@ -104,12 +104,12 @@ traits:
       is: [validate]
       body:
         application/json:
-          schema: permissionUser
+          schema: permissionUser.json
       responses:
         201:
           body:
             application/json:
-              schema: permissionUser
+              schema: permissionUser.json
         400:
           description: "Bad request"
           body:
@@ -127,7 +127,7 @@ traits:
           200:
             body:
               application/json:
-                schema: permissionUser
+                schema: permissionUser.json
           403:
             description: "Access Denied"
             body:
@@ -147,12 +147,12 @@ traits:
         description: Modify an existing user
         body:
           application/json:
-            schema: permissionUser
+            schema: permissionUser.json
         responses:
           200:
             body:
               application/json:
-                schema: permissionUser
+                schema: permissionUser.json
           400:
             description: "Bad request"
             body:
@@ -298,13 +298,13 @@ traits:
       is: [validate]
       body:
         application/json:
-          schema: permission
+          schema: permission.json
       responses:
         201:
           body:
             application/json:
               schema:
-                permission
+                permission.json
         400:
           description: "Bad request"
           body:
@@ -322,7 +322,7 @@ traits:
           200:
             body:
               application/json:
-                schema: permission
+                schema: permission.json
           404:
             description: "Permission not found"
             body:
@@ -337,12 +337,12 @@ traits:
         description: Modify an existing permission
         body:
           application/json:
-            schema: permission
+            schema: permission.json
         responses:
           200:
             body:
               application/json:
-                schema: permission
+                schema: permission.json
           400:
             description: "Bad request"
             body:

--- a/ramls/mod-users/groups.raml
+++ b/ramls/mod-users/groups.raml
@@ -8,13 +8,13 @@ documentation:
     content: This documents the API calls that can be made to query and manage user groups of the system
 
 schemas:
-  - usergroup: !include ../../schemas/mod-users/usergroup.json
+  - usergroup.json: !include ../../schemas/mod-users/usergroup.json
   - usergroups: !include ../../schemas/mod-users/usergroups.json
   - userdata: !include ../../schemas/mod-users/userdata.json
   - userdataCollection: !include ../../schemas/mod-users/userdataCollection.json
   - errors: !include ../../schemas/errors.schema
-  - error: !include ../../schemas/error.schema
-  - parameters: !include ../../schemas/parameters.schema
+  - error.schema: !include ../../schemas/error.schema
+  - parameters.schema: !include ../../schemas/parameters.schema
 
 traits:
   - secured: !include ../../traits/auth.raml
@@ -33,7 +33,7 @@ resourceTypes:
       exampleCollection: !include ../../examples/mod-users/groups.sample
       exampleItem: !include ../../examples/mod-users/group.sample
       schemaCollection: usergroups
-      schemaItem: usergroup
+      schemaItem: usergroup.json
   get:
     is: [
       searchable: {description: "with valid searchable fields", example: "name=aaa"},
@@ -47,4 +47,4 @@ resourceTypes:
     type:
       collection-item:
         exampleItem: !include ../../examples/mod-users/group.sample
-        schema: usergroup
+        schema: usergroup.json

--- a/ramls/mod-users/users.raml
+++ b/ramls/mod-users/users.raml
@@ -8,11 +8,11 @@ documentation:
     content: This documents the API calls that can be made to query and manage users of the system
 
 schemas:
-  - userdata: !include ../../schemas/mod-users/userdata.json
+  - userdata.json: !include ../../schemas/mod-users/userdata.json
   - userdataCollection: !include ../../schemas/mod-users/userdataCollection.json
   - errors: !include ../../schemas/errors.schema
-  - error: !include ../../schemas/error.schema
-  - parameters: !include ../../schemas/parameters.schema
+  - error.schema: !include ../../schemas/error.schema
+  - parameters.schema: !include ../../schemas/parameters.schema
 
 traits:
   - secured: !include ../../traits/auth.raml
@@ -34,7 +34,7 @@ resourceTypes:
       exampleCollection: !include ../../examples/mod-users/user_collection.sample
       exampleItem: !include ../../examples/mod-users/user.sample
       schemaCollection: userdataCollection
-      schemaItem: userdata
+      schemaItem: userdata.json
   get:
     is: [
       searchable: {description: "with valid searchable fields", example: "active=true"},
@@ -49,6 +49,6 @@ resourceTypes:
     type:
       collection-item:
         exampleItem: !include ../../examples/mod-users/user.sample
-        schema: userdata
+        schema: userdata.json
     get:
       description: Get a single user

--- a/ramls/tenant.raml
+++ b/ramls/tenant.raml
@@ -10,8 +10,8 @@ traits:
 schemas:
   - tenantAttributes: !include ../schemas/moduleInfo.schema
   - errors: !include ../schemas/errors.schema
-  - error: !include ../schemas/error.schema
-  - parameters: !include ../schemas/parameters.schema
+  - error.schema: !include ../schemas/error.schema
+  - parameters.schema: !include ../schemas/parameters.schema
 
 /_/tenant:
   post:

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,4 +1,1 @@
-As a workaround to FOLIO-573, when any schema file refers to an additional schema file,
-then the filename of the second referenced schema must be exactly the same as the
-"key" name in the RAML "schemas" section, which is being used in the $ref of the parent schema.
-For each such schema, please git add and commit a symbolic link to facilitate this.
+As a workaround to FOLIO-573, when any schema file refers to an additional schema file, then use the filename of that referenced second schema as the "key" name in the RAML "schemas" section, and wherever that schema is utilised in RAML and schema files.

--- a/schemas/error
+++ b/schemas/error
@@ -1,1 +1,0 @@
-error.schema

--- a/schemas/error.schema
+++ b/schemas/error.schema
@@ -13,7 +13,7 @@
     },
     "parameters": {
       "type": "object",
-      "$ref": "parameters"
+      "$ref": "parameters.schema"
     }
   },
   "required": [

--- a/schemas/errors.schema
+++ b/schemas/errors.schema
@@ -7,7 +7,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "$ref": "error"
+        "$ref": "error.schema"
       }
     },
     "total_records": {

--- a/schemas/mod-login/credentialsListObject.json
+++ b/schemas/mod-login/credentialsListObject.json
@@ -8,7 +8,7 @@
       "id": "credentialsListObject",
       "items": {
         "type": "object",
-        "$ref": "credentials"
+        "$ref": "credentials.json"
       }
     },
     "totalRecords": {

--- a/schemas/mod-permissions/okapiPermissionSet.json
+++ b/schemas/mod-permissions/okapiPermissionSet.json
@@ -9,7 +9,7 @@
             "type" : "array",
             "items" :  {
                 "type" : "object",
-                "$ref" : "okapiPermission"
+                "$ref" : "okapiPermission.json"
             }
         }
     }

--- a/schemas/mod-permissions/permissionListObject.json
+++ b/schemas/mod-permissions/permissionListObject.json
@@ -7,7 +7,7 @@
       "id": "permissionsListObject",
       "items": {
         "type": "object",
-        "$ref": "permission"
+        "$ref": "permission.json"
       }
     },
     "totalRecords": {

--- a/schemas/mod-permissions/permissionUserListObject.json
+++ b/schemas/mod-permissions/permissionUserListObject.json
@@ -7,7 +7,7 @@
       "id": "permissionUsersListObject",
       "items": {
         "type": "object",
-        "$ref": "permissionUser"
+        "$ref": "permissionUser.json"
       }
     },
     "totalRecords": {

--- a/schemas/mod-users/userdataCollection.json
+++ b/schemas/mod-users/userdataCollection.json
@@ -7,7 +7,7 @@
       "id": "usersData",
       "items": {
         "type": "object",
-        "$ref": "userdata"
+        "$ref": "userdata.json"
       }
     },
     "total_records": {

--- a/schemas/mod-users/usergroups.json
+++ b/schemas/mod-users/usergroups.json
@@ -7,7 +7,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "$ref": "usergroup"
+        "$ref": "usergroup.json"
       }
     },
     "total_records": {

--- a/schemas/parameters
+++ b/schemas/parameters
@@ -1,1 +1,0 @@
-parameters.schema


### PR DESCRIPTION
Ready to merge.

Using filename as schema key and to link one schema to a second schema.

This avoids the potentially fragile symlink solution.