### PR TITLE
Add "errors" schema to mod-users-bl.raml

### DIFF
--- a/ramls/mod-users-bl/mod-users-bl.raml
+++ b/ramls/mod-users-bl/mod-users-bl.raml
@@ -14,6 +14,7 @@ schemas:
   - ../mod-users/usergroup.json: !include ../../schemas/mod-users/usergroup.json
   - ../mod-permissions/permissionUser.json: !include ../../schemas/mod-permissions/permissionUser.json
   - ../mod-login/credentials.json: !include ../../schemas/mod-login/credentials.json
+  - errors: !include ../../schemas/errors.schema
 
 traits:
   - secured: !include ../../traits/auth.raml


### PR DESCRIPTION
It is used by traits/validation.raml
Fixes warning from raml-cop