### PR TITLE
Camel case "additionalItems" and "uniqueItems" in the codex schema

### DIFF
--- a/schemas/codex/coverage.json
+++ b/schemas/codex/coverage.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "http://json-schema.org/schema#",
+	"$schema": "http://json-schema.org/draft-04/schema#",
 	"title": "Codex Coverage Schema",
 	"type": "object",
 	"additionalProperties": false,
@@ -19,8 +19,8 @@
 						"type": "string"
 					}
 				},
-				"additionalitems": true,
-				"uniqueitems": true
+				"additionalItems": true,
+				"uniqueItems": true
 			}
 		},
 		"statement": {
@@ -39,8 +39,8 @@
 					}
 				}
 			},
-			"additionalitems": true,
-			"uniqueitems": true
+			"additionalItems": true,
+			"uniqueItems": true
 		}
 	},
 	"required": [

--- a/schemas/codex/instance.json
+++ b/schemas/codex/instance.json
@@ -29,8 +29,8 @@
 					}
 				}
 			},
-			"additionalitems": true,
-			"uniqueitems": true
+			"additionalItems": true,
+			"uniqueItems": true
 		},
 		"publisher": {
 			"type": "string"
@@ -57,8 +57,8 @@
 					}
 				}
 			},
-			"additionalitems": true,
-			"uniqueitems": true
+			"additionalItems": true,
+			"uniqueItems": true
 		},
 		"source": {
 			"type": "string"

--- a/schemas/codex/item.json
+++ b/schemas/codex/item.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "http://json-schema.org/schema#",
+	"$schema": "http://json-schema.org/draft-04/schema#",
 	"title": "Codex Item Schema",
 	"type": "object",
 	"additionalProperties": false,
@@ -35,8 +35,8 @@
 					}
 				}
 			},
-			"additionalitems": true,
-			"uniqueitems": true
+			"additionalItems": true,
+			"uniqueItems": true
 		},
 		"publisher": {
 			"type": "string"
@@ -63,8 +63,8 @@
 					}
 				}
 			},
-			"additionalitems": true,
-			"uniqueitems": true
+			"additionalItems": true,
+			"uniqueItems": true
 		},
 		"source": {
 			"type": "string"
@@ -95,7 +95,7 @@
 			"items": {
 				"type": "object"
 			},
-			"additionalitems": true
+			"additionalItems": true
 		},
 		"itemStatus": {
 			"type": "string"

--- a/schemas/codex/location.json
+++ b/schemas/codex/location.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "http://json-schema.org/schema#",
+	"$schema": "http://json-schema.org/draft-04/schema#",
 	"title": "Codex Location Schema",
 	"type": "object",
 	"additionalProperties": false,
@@ -21,8 +21,8 @@
 			"items": {
 				"type": "object"
 			},
-			"additionalitems": true,
-			"uniqueitems": true
+			"additionalItems": true,
+			"uniqueItems": true
 		},
 		"platform": {
 			"type": "string"

--- a/schemas/codex/package.json
+++ b/schemas/codex/package.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "http://json-schema.org/schema#",
+	"$schema": "http://json-schema.org/draft-04/schema#",
 	"title": "Codex Package Schema",
 	"type": "object",
 	"properties": {


### PR DESCRIPTION
The codex schema files had properties that were not in line with draft 4
of the JSON schema specification. It was unclear if the properties were
honored when provided as "additionalitems" and "uniqueitems". The
specification requires these properties to be camel case.