### PR TITLE
Performance: use cql == exact match instead of cql = substring match

### DIFF
--- a/traits/searchable.raml
+++ b/traits/searchable.raml
@@ -9,7 +9,7 @@
 
             <<description>>
           example: |
-            (username="ab*" or personal.firstName="ab*" or personal.lastName="ab*") and active="true" sortby personal.lastName personal.firstName barcode
+            (username=="ab*" or personal.firstName=="ab*" or personal.lastName=="ab*") and active=="true" sortby personal.lastName personal.firstName barcode
 
             <<example>>
           required: false


### PR DESCRIPTION
## Purpose
Show a CQL query example that uses a fast exact match syntax (`==`) and not the slow performance substring match (`=`).

## Approach
Using the right truncation match is fast. The substring match requires a word boundary regexp match that is slow on big tables.

## Learning
README at https://github.com/folio-org/cql2pgjson-java
Link list at http://dev.folio.org/doc/glossary#cql
