### PR TITLE
Add metadata.schema to main mod-users-bl raml

### DIFF
--- a/ramls/mod-users-bl/mod-users-bl.raml
+++ b/ramls/mod-users-bl/mod-users-bl.raml
@@ -16,6 +16,7 @@ schemas:
   - mod-login/credentials.json: !include ../../schemas/mod-login/credentials.json
   - mod-users/proxyfor.json: !include ../../schemas/mod-users/proxyfor.json
   - errors: !include ../../schemas/errors.schema
+  - metadata.schema: !include ../../schemas/metadata.schema
 
 traits:
   - secured: !include ../../traits/auth.raml


### PR DESCRIPTION
Add the "metadata.schema" schema to the mod-users-bl RAML, in order to accommodate new userdata.