### PR TITLE
Cql schema

### DIFF
--- a/schemas/CQLSchema.schema
+++ b/schemas/CQLSchema.schema
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "CQLSchema",
+  "description": "JSON schema for capturing CQL search schemas",
+  "type": "object",
+  "properties": {
+    "name": {"type": "string"},
+    "description": {"type": "string"},
+    "indexes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {"type": "string"},
+          "description": {"type": "string"},
+          "type": {
+            "type": "string", 
+            "enum": ["string", "number"], 
+            "default": "string"
+          },
+          "capability": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["search", "sort", "filter"]
+            },
+            "default": ["search"],
+            "uniqueItems": true
+          }
+        },
+        "additionalProperties": false,
+        "required": ["name"]
+      },
+      "uniqueItems": true
+    },
+    "operators": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type" : {"type": "string", "enum": ["AND", "OR", "NOT", "PROX"]},
+          "supported": {"type": "boolean"},
+        },
+        "additionalProperties": false,
+        "required": ["type", "supported"]
+      },
+      "default": [
+      	{"type": "AND", "supported": true},
+      	{"type": "OR", "supported": true},
+      	{"type": "NOT", "supported": true},
+      	{"type": "PROX", "supported": false}
+      ],
+      "uniqueItems": true
+    }
+  },
+  "additionalProperties": false,
+  "required": ["name", "indexes"]
+}

--- a/schemas/codex/codex_instance_cqlschema.json
+++ b/schemas/codex/codex_instance_cqlschema.json
@@ -1,0 +1,51 @@
+{
+  "name": "CODEX Instance CQL Schema",
+  "description": "Supported indexes and operators in CODEX instance search",
+  "indexes": [
+  { 
+    "name" : "title",
+    "type" : "string",
+    "capability" : ["search", "sort"]
+  },
+  { 
+    "name" : "publisher",
+    "type" : "string"
+  },
+  { 
+    "name" : "subject",
+    "type" : "string"
+  },
+  { 
+    "name" : "identifier",
+    "type" : "string"
+  },
+  { 
+    "name" : "location",
+    "type" : "string",
+    "capability" : ["filter"]
+  },
+  { 
+    "name" : "type",
+    "type" : "string",
+    "capability" : ["filter"]
+  }
+  ],
+  "operators": [
+  {
+    "type" : "AND",
+    "supported" : false
+  },
+  {
+    "type" : "OR",
+    "supported" : false
+  },
+  {
+    "type" : "NOT",
+    "supported" : false
+  },
+  {
+    "type" : "PROX",
+    "supported" : false
+  }
+  ]
+}


### PR DESCRIPTION
JSON schema for capturing CQL search schema: indices (search, sort, filter) and operators. Search schema is not always 1:1 equivalent to the meta-data schema: some meta-data fields may not be supported in searching/sorting and vice-versa: "virtual" indices with no direct representation in the schema may be required. This schema allow to capture basic capabilities.