### PR TITLE
FOLIO-601 fix raml examples codex

### DIFF
--- a/examples/codex/instance.sample
+++ b/examples/codex/instance.sample
@@ -6,7 +6,7 @@
   "contributor": [],
   "publisher": "first publisher",
   "date": "first date",
-  "type": "newsletter",
+  "type": "newsletters",
   "format": "first format",
   "identifier": [
     {

--- a/examples/codex/instanceCollection.sample
+++ b/examples/codex/instanceCollection.sample
@@ -8,7 +8,7 @@
       "contributor": [],
       "publisher": "first publisher",
       "date": "first date",
-      "type": "newsletter",
+      "type": "newsletters",
       "format": "first format",
       "identifier": [
         {
@@ -33,7 +33,7 @@
       "contributor": [],
       "publisher": "second publisher",
       "date": "second date",
-      "type": "report",
+      "type": "reports",
       "format": "second format",
       "identifier": [
         {


### PR DESCRIPTION
## Purpose:
Keep the basic raml examples aligned with their schema.
Also assists raml-cop to cleanly report other issues.