### PR TITLE
Fix pathname to resultInfo.schema

### DIFF
--- a/schemas/codex/instanceCollection.json
+++ b/schemas/codex/instanceCollection.json
@@ -15,7 +15,7 @@
       "type": "integer"
     },
     "resultInfo" : {
-      "$ref" : "resultInfo.schema"
+      "$ref" : "../resultInfo.schema"
     }
   },
   "required": [


### PR DESCRIPTION
## Purpose

Was causing an obscure message from raml-cop …

```
[../../rtypes/collection-get.raml:17:16] WARNING Can not parse JSON
example: Unexpected end of JSON input
```
i.e. line 18 of this included file.

## Approach

Use actual pathname to the schema file.