### PR TITLE
Rename 'type' to 'resourceType'

### DIFF
--- a/schemas/codex/codex_instance_cqlschema.json
+++ b/schemas/codex/codex_instance_cqlschema.json
@@ -44,7 +44,7 @@
       ]
     },
     {
-      "name": "type",
+      "name": "resourceType",
       "type": "string",
       "description": "Resource type filter, see CODEX instance schema for the list of allowed values",
       "capability": [


### PR DESCRIPTION
Matches the index-name as used in the UX documents.

Camel-case used in accordance with precedent in other CQL context sets
such as the CQL Set itself
(https://www.loc.gov/standards/sru/cql/contextSets/cql-context-set-v1-1.html)
which includes names like `resultSetId`, `serverChoice` and
`allRecords`.
