### PR TITLE
FOLIO-1040 Declare metadata.schema in users.raml

### DIFF
--- a/ramls/mod-users/users.raml
+++ b/ramls/mod-users/users.raml
@@ -14,6 +14,7 @@ schemas:
   - error.schema: !include ../../schemas/error.schema
   - parameters.schema: !include ../../schemas/parameters.schema
   - ../resultInfo.schema: !include ../../schemas/resultInfo.schema
+  - ../metadata.schema: !include ../../schemas/metadata.schema
 
 traits:
   - secured: !include ../../traits/auth.raml


### PR DESCRIPTION
It is referenced in schemas/mod-users/userdata.json

See [MODUSERS-58](https://issues.folio.org/browse/MODUSERS-58) for an interesting journey regarding how it revealed itself.
TLDR, that file was being provided by an earlier-processed raml file. A newer version of vagrant processed them in a different order.
