### PR TITLE
RMB-136: Raise pageable's maximum offset and maximum limit to 2147483647.

### DIFF
--- a/traits/pageable.raml
+++ b/traits/pageable.raml
@@ -6,7 +6,7 @@
           example: 0
           default: 0
           minimum: 0
-          maximum: 1000
+          maximum: 2147483647
         limit:
           description: Limit the number of elements returned in the response
           type: integer
@@ -14,4 +14,4 @@
           example: 10
           default: 10
           minimum: 0
-          maximum: 100
+          maximum: 2147483647


### PR DESCRIPTION
Integer.MAX_VALUE = 2147483647

## Purpose
Let the caller decide about the page size.

## Approach
Implementations using int will still work without overflow.

Backward compatibility: The defaults remain the same: offset=0, limit=10.