### PR TITLE
FOLIO-1040 ensure schema declarations 2

### DIFF
--- a/ramls/mod-users-bl/mod-users-bl.raml
+++ b/ramls/mod-users-bl/mod-users-bl.raml
@@ -16,6 +16,8 @@ schemas:
   - mod-login/credentials.json: !include ../../schemas/mod-login/credentials.json
   - mod-users/proxyfor.json: !include ../../schemas/mod-users/proxyfor.json
   - errors: !include ../../schemas/errors.schema
+  - error.schema: !include ../../schemas/error.schema
+  - parameters.schema: !include ../../schemas/parameters.schema
   - metadata.schema: !include ../../schemas/metadata.schema
 
 traits:

--- a/ramls/mod-users/groups.raml
+++ b/ramls/mod-users/groups.raml
@@ -10,11 +10,12 @@ documentation:
 schemas:
   - usergroup.json: !include ../../schemas/mod-users/usergroup.json
   - usergroups: !include ../../schemas/mod-users/usergroups.json
-  - userdata: !include ../../schemas/mod-users/userdata.json
+  - userdata.json: !include ../../schemas/mod-users/userdata.json
   - userdataCollection: !include ../../schemas/mod-users/userdataCollection.json
   - errors: !include ../../schemas/errors.schema
   - error.schema: !include ../../schemas/error.schema
   - parameters.schema: !include ../../schemas/parameters.schema
+  - ../resultInfo.schema: !include ../../schemas/resultInfo.schema
   - ../metadata.schema: !include ../../schemas/metadata.schema
 
 traits:


### PR DESCRIPTION
This fixes the remaining inconsistencies with declarations of schema.

As noted in the commit messages, these features are declared but not currently being used by these RAML files. If they were eventually used, then they would need this configuration.
