### PR TITLE
MODUSERS-62

### DIFF
--- a/schemas/mod-users/proxyfor.json
+++ b/schemas/mod-users/proxyfor.json
@@ -12,6 +12,26 @@
     "id": {
       "type": "string"
     },
+    "requestForSponsor": {
+      "type": "string"
+    },
+    "createdDate": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "notificationsTo": {
+      "type": "string"
+    },
+    "accrueTo": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string"
+    },
+    "expirationDate": {
+      "type": "string",
+      "format": "date-time"
+    },	
     "meta": {
       "type": "object"
     }


### PR DESCRIPTION
move fields in the meta section into their own top level fields

Purpose:
Currently the metadata fields of the proxyFor are in a generic meta section in the json schema - there is no indication of what these fields are , no validation, etc...
The purpose here is to explicitly declare these fields on their own within the schema