### PR TITLE
Add id property to error schema to facilitate response validation

### DIFF
--- a/schemas/error.schema
+++ b/schemas/error.schema
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
+  "id":"/raml-util/schemas/error.schema",
   "properties": {
     "message": {
       "type": "string"

--- a/schemas/error.schema
+++ b/schemas/error.schema
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "id":"/raml-util/schemas/error.schema",
+  "id": "/raml-util/schemas/error.schema",
   "properties": {
     "message": {
       "type": "string"

--- a/schemas/errors.schema
+++ b/schemas/errors.schema
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "id":"/raml-util/schemas/errors.schema",
+  "id": "/raml-util/schemas/errors.schema",
   "properties": {
     "errors": {
       "id": "errors",

--- a/schemas/errors.schema
+++ b/schemas/errors.schema
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
+  "id":"/raml-util/schemas/errors.schema",
   "properties": {
     "errors": {
       "id": "errors",

--- a/schemas/parameters.schema
+++ b/schemas/parameters.schema
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id":"/raml-util/schemas/parameters.schema",
+  "id": "/raml-util/schemas/parameters.schema",
   "type": "array",
   "items": {
     "type": "object",

--- a/schemas/parameters.schema
+++ b/schemas/parameters.schema
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id":"/raml-util/schemas/parameters.schema",
   "type": "array",
   "items": {
     "type": "object",


### PR DESCRIPTION
## Purpose
I've been trying to validate API responses during tests, using Rest Assured and https://github.com/nidi3/raml-tester, similarly to Okapi and encountered an issue with loading the error schema (due to how ref parameters are resolved)

## Approach
This change introduces the id property in order to provide relative address for the schema, providing an alternative way for tools to find the correct schema.

I've used raml-cop to validate RAML that uses these schema and it still reports them as valid.

I've checked the branch with mod-circulation-storage and mod-inventory-storage and it does not seem to adversely affect building with the RAML module builder.

#### TODOS and Open Questions
The id properties are based upon the assumption, that I believe we have standardised upon (and other aspects rely upon), that the raml repository is used as a submodule in the raml-util subdirectory of where the raml is defined.

## Learning
I found this reference on structuring schema to be useful: https://spacetelescope.github.io/understanding-json-schema/structuring.html#the-id-property

And https://github.com/nidi3/raml-tester/issues/49 helped me understand more about the tool
