### PR TITLE
FOLIO-1213 remove schema id property

### DIFF
--- a/schemas/error.schema
+++ b/schemas/error.schema
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "id": "/raml-util/schemas/error.schema",
   "properties": {
     "message": {
       "type": "string"

--- a/schemas/errors.schema
+++ b/schemas/errors.schema
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "id": "/raml-util/schemas/errors.schema",
   "properties": {
     "errors": {
       "id": "errors",

--- a/schemas/parameters.schema
+++ b/schemas/parameters.schema
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "/raml-util/schemas/parameters.schema",
   "type": "array",
   "items": {
     "type": "object",


### PR DESCRIPTION
It causes issues for our raml2html. Undoing it until further investigation.

The id was added in pull #77

See [FOLIO-1213](https://issues.folio.org/browse/FOLIO-1213).
