### PR TITLE
Add reference to tags.shema to users.raml

### DIFF
--- a/ramls/mod-users/users.raml
+++ b/ramls/mod-users/users.raml
@@ -15,6 +15,7 @@ schemas:
   - parameters.schema: !include ../../schemas/parameters.schema
   - ../resultInfo.schema: !include ../../schemas/resultInfo.schema
   - ../metadata.schema: !include ../../schemas/metadata.schema
+  - ../tags.schema: !include ../../schemas/tags.schema
 
 traits:
   - secured: !include ../../traits/auth.raml


### PR DESCRIPTION
Fixes a forgotten reference to tags.schema in users.raml
