### PR TITLE
MODTAG-2 declare tags schema

### DIFF
--- a/ramls/mod-users-bl/mod-users-bl.raml
+++ b/ramls/mod-users-bl/mod-users-bl.raml
@@ -19,6 +19,7 @@ schemas:
   - error.schema: !include ../../schemas/error.schema
   - parameters.schema: !include ../../schemas/parameters.schema
   - metadata.schema: !include ../../schemas/metadata.schema
+  - tags.schema: !include ../../schemas/tags.schema
 
 traits:
   - secured: !include ../../traits/auth.raml

--- a/ramls/mod-users/groups.raml
+++ b/ramls/mod-users/groups.raml
@@ -17,6 +17,7 @@ schemas:
   - parameters.schema: !include ../../schemas/parameters.schema
   - ../resultInfo.schema: !include ../../schemas/resultInfo.schema
   - ../metadata.schema: !include ../../schemas/metadata.schema
+  - ../tags.schema: !include ../../schemas/tags.schema
 
 traits:
   - secured: !include ../../traits/auth.raml


### PR DESCRIPTION
The tags.schema needs to be declared in any RAML file that uses schema that refer to it.
