### PR TITLE
FOLIO-1220 declare all schema

### DIFF
--- a/ramls/mod-users/proxiesFor.raml
+++ b/ramls/mod-users/proxiesFor.raml
@@ -13,6 +13,7 @@ schemas:
   - errors: !include ../../schemas/errors.schema
   - error.schema: !include ../../schemas/error.schema
   - parameters.schema: !include ../../schemas/parameters.schema
+  - ../metadata.schema: !include ../../schemas/metadata.schema
 
 traits:
   - secured: !include ../../traits/auth.raml

--- a/schemas/mod-permissions/permission.json
+++ b/schemas/mod-permissions/permission.json
@@ -37,7 +37,7 @@
     },
     "dummy" : {
       "type" : "boolean"
-	},
+    },
     "metadata" : {
       "type" : "object",
       "$ref" : "../metadata.schema"


### PR DESCRIPTION
## Purpose
All schema that are referenced in other schema need to be declared in any RAML file that uses them.

See notes in [FOLIO-1220](https://issues.folio.org/browse/FOLIO-1220)
