### PR TITLE
Add servicePoints and defaultServicePoint

### DIFF
--- a/schemas/mod-users/userdata.json
+++ b/schemas/mod-users/userdata.json
@@ -128,6 +128,15 @@
     "tags": {
       "type": "object",
       "$ref": "../tags.schema"
+    },
+    "servicePoints": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "defaultServicePoint": {
+      "type": "string"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
## Purpose
For [MODUSERS-76](https://issues.folio.org/browse/MODUSERS-76), [MODUSERSBL-34](https://issues.folio.org/browse/MODUSERBL-34), [UIU-546](https://issues.folio.org/browse/UIU-546) and all associated service point JIRAs, we need to be able to set:

1. The service points that a given user is allowed to work from.
1. The default service point selected when a given user is logging in. 

## Approach
Adds `servicePoints` array-of-string and `defaultServicePoint` string fields to the `userdata` object. The strings will be IDs of the service points. Both are optional.

## Post-Merge TODOs
- [ ] Update `mod-users` 
- [ ] Update `mod-users-bl`