### PR TITLE
FOLIO-1027 enable lint-raml jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,12 @@ pipeline {
       }
     }
 
+    stage('Lint raml-cop') {
+      steps {
+        runLintRamlCop()
+      }
+    }
+
     stage('Publish API Docs') {
       steps {
         sh 'python3 /usr/local/bin/generate_api_docs.py -r raml -l info -o folio-api-docs'


### PR DESCRIPTION
@funkymalc , this intends to just get the "lint-raml" job happening on the merge to master.

This repo's Jenkinsfile is different to the mod-* repos where this job is now operating, so i hope that this is all that is needed.

Later i will explore how to configure it for branch builds too.
