### PR TITLE
Make subject searchable

### DIFF
--- a/schemas/codex/codex_instance_cqlschema.json
+++ b/schemas/codex/codex_instance_cqlschema.json
@@ -35,7 +35,10 @@
     },
     {
       "name": "subject",
-      "type": "string"
+      "type": "string",
+      "capability": [
+        "search"
+      ]
     },
     {
       "name": "identifier",


### PR DESCRIPTION
## Purpose
If https://github.com/folio-org/mod-codex-ekb/pull/72 is merged, then users will be able to search by "subject" in KB. Looks like search by subject is already supported in inventory and is disabled at the moment from the UI for KB. Since, users will be able to search by subject both from inventory and KB going forward, this PR makes "subject" searchable. Unsure if we should also make it sortable but that is for further discussion.

## Approach
Make subject searchable.
