### PR TITLE
FOLIO-1598 Disable generate-api-docs on raml0.8 branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,22 +27,6 @@ pipeline {
       }
     }
 
-    stage('Publish API Docs') {
-      when {
-        branch 'master'
-      }
-      steps {
-        sh 'python3 /usr/local/bin/generate_api_docs.py -r raml -l info -o folio-api-docs'
-        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', 
-                          accessKeyVariable: 'AWS_ACCESS_KEY_ID', 
-                          credentialsId: 'jenkins-aws', 
-                          secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-          sh 'aws s3 sync folio-api-docs s3://foliodocs/api'
-        }
-      }
-    }
-    
-
   } // end stages
 
   post {


### PR DESCRIPTION
The current infrastructure can only publish one set of generated API docs.
So only do the default branch "raml1.0".
