### PR TITLE
FOLIO-1481 Split lint-raml into two stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,12 @@ pipeline {
       }
     }
 
+    stage('Lint raml schema') {
+      steps {
+        runLintRamlSchema()
+      }
+    }
+
     stage('Publish API Docs') {
       when {
         branch 'raml1.0'


### PR DESCRIPTION
First do "Lint raml-cop" to assess the RAML and examples against schema.
Then do "Lint raml schema" to assess the RAML Schema descriptions FOLIO-1447.
Reduces potential to overlook RAML errors.
