### PR TITLE
Fix typo in schema

### DIFF
--- a/schemas/codex/packageCollection.json
+++ b/schemas/codex/packageCollection.json
@@ -7,7 +7,7 @@
     "packages": {
       "type": "array",
       "description": "Collection of packages",
-      "packages": {
+      "items": {
         "type": "object",
         "$ref": "package.json"
       }

--- a/schemas/codex/sourceCollection.json
+++ b/schemas/codex/sourceCollection.json
@@ -7,7 +7,7 @@
     "sources": {
       "type": "array",
       "description": "Collection of sources",
-      "packages": {
+      "items": {
         "type": "object",
         "$ref": "source.json"
       }


### PR DESCRIPTION
In json schema, type of object in the array is described with "items" property. Without this property classes are generated with type List\<Object\> instead of List\<Instance\> and List\<Package\>