### PR TITLE
MODCXEKB-93 Change codex collection endpoints to use get-only rtype

### DIFF
--- a/ramls/codex/codex-packages.raml
+++ b/ramls/codex/codex-packages.raml
@@ -1,5 +1,5 @@
 #%RAML 1.0
-title: Codex Packages API
+title: Codex Packages
 baseUri: https://github.com/folio-org/mod-codex-ekb
 version: v1
 
@@ -20,16 +20,15 @@ traits:
   searchable: !include ../../traits/searchable.raml
 
 resourceTypes:
-  collection-get: !include ../../rtypes/collection-get.raml
+  get-only: !include ../../rtypes/get-only.raml
   collection-item-get: !include ../../rtypes/item-collection-get.raml
-  item-get: !include ../../rtypes/get-only.raml
 
 /codex-packages:
   displayName: Codex packages
   description: Codex packages collection
   type:
-    collection-get:
-      schemaCollection: packageCollection
+    get-only:
+      schema: packageCollection
       exampleCollection: !include ../../examples/codex/packageCollection.sample
   get:
     is: [
@@ -37,6 +36,13 @@ resourceTypes:
       pageable,
       validate
     ]
+    responses:
+      401:
+        description: "Not authorized to perform requested action"
+        body:
+          text/plain:
+            example: |
+              "unable to list packages -- unauthorized"
   /{id}:
     displayName: Codex package
     description: Get a specific codex package
@@ -49,7 +55,7 @@ resourceTypes:
   displayName: Codex packages sources
   description: Codex packages sources
   type:
-    item-get:
+    get-only:
         schema: sourceCollection
         exampleCollection: !include ../../examples/codex/sourceCollection.sample
   get:

--- a/ramls/codex/codex.raml
+++ b/ramls/codex/codex.raml
@@ -1,5 +1,5 @@
 #%RAML 1.0
-title: Codex API
+title: Codex
 baseUri: https://github.com/folio-org/mod-codex-ekb
 version: v1
 
@@ -19,15 +19,15 @@ traits:
   searchable: !include ../../traits/searchable.raml
 
 resourceTypes:
-  collection-get: !include ../../rtypes/collection-get.raml
+  get-only: !include ../../rtypes/get-only.raml
   collection-item-get: !include ../../rtypes/item-collection-get.raml
 
 /codex-instances:
   displayName: Codex instances
   description: Codex instance collection
   type:
-    collection-get:
-      schemaCollection: instanceCollection
+    get-only:
+      schema: instanceCollection
       exampleCollection: !include ../../examples/codex/instanceCollection.sample
   get:
     is: [
@@ -35,6 +35,13 @@ resourceTypes:
       pageable,
       validate
     ]
+    responses:
+      401:
+        description: "Not authorized to perform requested action"
+        body:
+          text/plain:
+            example: |
+              "unable to list instances -- unauthorized"
   /{id}:
     displayName: Codex instance
     description: Get a specific codex instance


### PR DESCRIPTION
## Purpose
Fix documentation errors described in  [MODCXEKB-93](https://issues.folio.org/browse/MODCXEKB-93)

## Approach
Use rtypes/get-only.raml for collection types, because according to descriptions collection-get is used for retrieving single item by id.
Add 401 response to collection endpoints. get-only.raml doesn't have 401 error so we need to declare it in codex/codex-packages raml files.

## Screenshots
Documentation after changes:
![image](https://user-images.githubusercontent.com/43238569/54423919-69b98b00-471a-11e9-96ba-3a57240460b7.png)
![image](https://user-images.githubusercontent.com/43238569/54423925-6d4d1200-471a-11e9-8f69-718222761c1b.png)

