### PR TITLE
MODCXMUX-37 - Create RAML for GET codex-instances-sources

### DIFF
--- a/ramls/codex/codex-instances-sources.raml
+++ b/ramls/codex/codex-instances-sources.raml
@@ -1,0 +1,30 @@
+#%RAML 1.0
+title: Codex Instances Sources
+baseUri: https://github.com/folio-org/mod-codex-ekb
+version: v1
+
+documentation:
+ - title: Codex Instances Sources API
+   content: This documents the FOLIO codex instances sources API
+
+types:
+  sourceCollection: !include ../../schemas/codex/sourceCollection.json
+
+traits:
+  language: !include ../../traits/language.raml
+
+resourceTypes:
+  get-only: !include ../../rtypes/get-only.raml
+
+
+/codex-instances-sources:
+  displayName: Codex instances sources
+  description: Codex instances sources
+  type:
+    get-only:
+        schema: sourceCollection
+        exampleCollection: !include ../../examples/codex/sourceCollection.sample
+  get:
+    displayName: Codex instances sources
+    description: GET a list of source modules that implement codex-instances-sources interface
+


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODCXMUX-37 there is a new endpoint introduced to get modules, which implement the codex-instances-sources interface.

## Approach
* added new raml file for codex-instances-sources endpoint.

## Screenshots
<img width="1540" alt="Screen Shot 2019-03-21 at 6 24 07 PM" src="https://user-images.githubusercontent.com/37537790/54768265-7f8deb00-4c07-11e9-81b1-a2353c9eeef2.png">

![2019-03-21_18-30-36](https://user-images.githubusercontent.com/37537790/54768354-ac420280-4c07-11e9-895b-00b154161a32.png)
