### PR TITLE
Jenkinsfile apidocs handle both default branch and master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,10 @@ pipeline {
 
     stage('Publish API Docs') {
       when {
-        branch 'raml1.0'
+        anyOf {
+          branch 'master'
+          branch 'raml1.0'
+        }
       }
       steps {
         sh 'python3 /usr/local/bin/generate_api_docs.py -r raml -l info -o folio-api-docs'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,15 +39,15 @@ pipeline {
       }
       steps {
         sh 'python3 /usr/local/bin/generate_api_docs.py -r raml -l info -o folio-api-docs'
-        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', 
-                          accessKeyVariable: 'AWS_ACCESS_KEY_ID', 
-                          credentialsId: 'jenkins-aws', 
+        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding',
+                          accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                          credentialsId: 'jenkins-aws',
                           secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
           sh 'aws s3 sync folio-api-docs s3://foliodocs/api'
         }
       }
     }
-    
+
 
   } // end stages
 


### PR DESCRIPTION
The Jenkins job "Publish API Docs" does run properly when using the default branch "raml1.0",
e.g. after merge of pull/119

However it does not run when using "master" branch,
e.g. after merge of pull/118 (see the Jenkins output, where it skipped this step).

Adjusted Jenkinsfile to handle both.