### PR TITLE
Add common uuid.schema

### DIFF
--- a/schemas/uuid.schema
+++ b/schemas/uuid.schema
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Regexp pattern for UUID validation",
+  "type": "string",
+  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$"
+}

--- a/schemas/uuid.schema
+++ b/schemas/uuid.schema
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "Regexp pattern for UUID validation",
+  "description": "A universally unique identifier (UUID), this is a 128-bit number used to identify a record and is shown in hex with dashes, for example 6312d172-f0cf-40f6-b27d-9fa8feaf332f; the UUID version must be from 1-5; see https://dev.folio.org/guides/uuids/",
   "type": "string",
   "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$"
 }


### PR DESCRIPTION
Many repositories have their own separate copy, same regex pattern, different description or no description.

This adds a shared version.

Copied from 
https://github.com/folio-org/data-import-raml-storage/blob/0f54dcefdcd3bba44e55a243dc05e6d92d356d4d/schemas/common/uuid.json