### PR TITLE
MODFIN-77 Fund API updates: POST

### DIFF
--- a/rtypes/collection-with-json-response.raml
+++ b/rtypes/collection-with-json-response.raml
@@ -25,7 +25,7 @@
               application/json:
                 example:
                   strict: false
-                  value: !include ../raml-util/examples/errors.sample
+                  value: !include ../examples/errors.sample
               text/plain:
                 example: "unable to list <<resourcePathName>> -- malformed parameter 'query', syntax error at column 6"
           401:
@@ -34,7 +34,7 @@
               application/json:
                 example:
                   strict: false
-                  value: !include ../raml-util/examples/errors.sample
+                  value: !include ../examples/errors.sample
               text/plain:
                 example: "unable to list <<resourcePathName>> -- unauthorized"
           500:
@@ -43,7 +43,7 @@
               application/json:
                 example:
                   strict: false
-                  value: !include ../raml-util/examples/errors.sample
+                  value: !include ../examples/errors.sample
               text/plain:
                 example: "internal server error, contact administrator"
 
@@ -70,7 +70,7 @@
               application/json:
                 example:
                   strict: false
-                  value: !include ../raml-util/examples/errors.sample
+                  value: !include ../examples/errors.sample
               text/plain:
                 example: |
                   "unable to add <<resourcePathName|!singularize>> -- malformed JSON at 13:3"
@@ -80,7 +80,7 @@
               application/json:
                 example:
                   strict: false
-                  value: !include ../raml-util/examples/errors.sample
+                  value: !include ../examples/errors.sample
               text/plain:
                 example: "unable to create <<resourcePathName>> -- unauthorized"
           500:
@@ -89,6 +89,6 @@
               application/json:
                 example:
                   strict: false
-                  value: !include ../raml-util/examples/errors.sample
+                  value: !include ../examples/errors.sample
               text/plain:
                 example: "Internal server error, contact administrator"

--- a/rtypes/collection-with-json-response.raml
+++ b/rtypes/collection-with-json-response.raml
@@ -1,0 +1,94 @@
+#%RAML 1.0 ResourceType
+# collection.raml
+#the raml making use of this collection must include the following
+#traits:
+# - orderable: !include traits/orderable.raml
+# - pageable:  !include traits/pageable.raml
+# - searchable: !include traits/searchable.raml
+      description: Collection of <<resourcePathName|!singularize>> items.
+      is: [language]
+
+      get:
+        description: Retrieve a list of <<resourcePathName|!singularize>> items.
+        responses:
+          200:
+            description: "Returns a list of <<resourcePathName|!singularize>> items"
+            body:
+              application/json:
+                type: <<schemaCollection>>
+                example:
+                  strict: false
+                  value: <<exampleCollection>>
+          400:
+            description: "Bad request, e.g. malformed request body or query parameter. Details of the error (e.g. name of the parameter or line/character number with malformed data) provided in the response."
+            body:
+              application/json:
+                example:
+                  strict: false
+                  value: !include ../raml-util/examples/errors.sample
+              text/plain:
+                example: "unable to list <<resourcePathName>> -- malformed parameter 'query', syntax error at column 6"
+          401:
+            description: "Not authorized to perform requested action"
+            body:
+              application/json:
+                example:
+                  strict: false
+                  value: !include ../raml-util/examples/errors.sample
+              text/plain:
+                example: "unable to list <<resourcePathName>> -- unauthorized"
+          500:
+            description: "Internal server error, e.g. due to misconfiguration"
+            body:
+              application/json:
+                example:
+                  strict: false
+                  value: !include ../raml-util/examples/errors.sample
+              text/plain:
+                example: "internal server error, contact administrator"
+
+      post:
+        description: Create a new <<resourcePathName|!singularize>> item.
+        body:
+          application/json:
+            type: <<schemaItem>>
+            example:
+              strict: false
+              value: <<exampleItem>>
+        responses:
+          201:
+            description: "Returns a newly created item, with server-controlled fields like 'id' populated"
+            headers:
+              Location:
+                description: URI to the created <<resourcePathName|!singularize>> item
+            body:
+              application/json:
+                example: <<exampleItem>>
+          400:
+            description: "Bad request, e.g. malformed request body or query parameter. Details of the error (e.g. name of the parameter or line/character number with malformed data) provided in the response."
+            body:
+              application/json:
+                example:
+                  strict: false
+                  value: !include ../raml-util/examples/errors.sample
+              text/plain:
+                example: |
+                  "unable to add <<resourcePathName|!singularize>> -- malformed JSON at 13:3"
+          401:
+            description: "Not authorized to perform requested action"
+            body:
+              application/json:
+                example:
+                  strict: false
+                  value: !include ../raml-util/examples/errors.sample
+              text/plain:
+                example: "unable to create <<resourcePathName>> -- unauthorized"
+          500:
+            description: "Internal server error, e.g. due to misconfiguration"
+            body:
+              application/json:
+                example:
+                  strict: false
+                  value: !include ../raml-util/examples/errors.sample
+              text/plain:
+                example: "Internal server error, contact administrator"

--- a/rtypes/item-collection-with-json-response.raml
+++ b/rtypes/item-collection-with-json-response.raml
@@ -1,0 +1,114 @@
+#%RAML 1.0 ResourceType
+# item-collection-with-json-response.raml
+    description: Entity representing a <<resourcePathName|!singularize>>
+    is: [language]
+
+    get:
+      description: |
+        Retrieve <<resourcePathName|!singularize>> item with given {<<resourcePathName|!singularize>>Id}
+      responses:
+        200:
+          description: "Returns item with a given ID"
+          body:
+            application/json:
+              type: <<schema>>
+              example:
+                strict: false
+                value: <<exampleItem>>
+        404:
+          description: "Item with a given ID not found"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../raml-util/examples/errors.sample
+            text/plain:
+              example: |
+                "<<resourcePathName|!singularize>> not found"
+        500:
+          description: "Internal server error, e.g. due to misconfiguration"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../raml-util/examples/errors.sample
+            text/plain:
+              example: "internal server error, contact administrator"
+    delete:
+      description: |
+        Delete <<resourcePathName|!singularize>> item with given {<<resourcePathName|!singularize>>Id}
+      responses:
+        204:
+         description: "Item deleted successfully"
+        404:
+          description: "Item with a given ID not found"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../raml-util/examples/errors.sample
+            text/plain:
+              example: |
+                "<<resourcePathName|!singularize>> not found"
+        400:
+          description: "Bad request, e.g. malformed request body or query parameter. Details of the error (e.g. name of the parameter or line/character number with malformed data) provided in the response."
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../raml-util/examples/errors.sample
+            text/plain:
+              example: |
+                "unable to delete <<resourcePathName|!singularize>> -- constraint violation"
+        500:
+          description: "Internal server error, e.g. due to misconfiguration"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../raml-util/examples/errors.sample
+            text/plain:
+              example: "Internal server error, contact administrator"
+
+    put:
+      description: |
+        Update <<resourcePathName|!singularize>> item with given {<<resourcePathName|!singularize>>Id}
+      body:
+        application/json:
+          type: <<schema>>
+          example:
+            strict: false
+            value: <<exampleItem>>
+      responses:
+        204:
+          description: "Item successfully updated"
+        404:
+          description: "Item with a given ID not found"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../raml-util/examples/errors.sample
+            text/plain:
+              example: |
+                "<<resourcePathName|!singularize>> not found"
+        400:
+          description: "Bad request, e.g. malformed request body or query parameter. Details of the error (e.g. name of the parameter or line/character number with malformed data) provided in the response."
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../raml-util/examples/errors.sample
+            text/plain:
+              example: |
+                "unable to update <<resourcePathName|!singularize>> -- malformed JSON at 13:4"
+        500:
+          description: "Internal server error, e.g. due to misconfiguration"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../raml-util/examples/errors.sample
+            text/plain:
+              example: "internal server error, contact administrator"
+

--- a/rtypes/item-collection-with-json-response.raml
+++ b/rtypes/item-collection-with-json-response.raml
@@ -21,7 +21,7 @@
             application/json:
               example:
                 strict: false
-                value: !include ../raml-util/examples/errors.sample
+                value: !include ../examples/errors.sample
             text/plain:
               example: |
                 "<<resourcePathName|!singularize>> not found"
@@ -31,7 +31,7 @@
             application/json:
               example:
                 strict: false
-                value: !include ../raml-util/examples/errors.sample
+                value: !include ../examples/errors.sample
             text/plain:
               example: "internal server error, contact administrator"
     delete:
@@ -46,7 +46,7 @@
             application/json:
               example:
                 strict: false
-                value: !include ../raml-util/examples/errors.sample
+                value: !include ../examples/errors.sample
             text/plain:
               example: |
                 "<<resourcePathName|!singularize>> not found"
@@ -56,7 +56,7 @@
             application/json:
               example:
                 strict: false
-                value: !include ../raml-util/examples/errors.sample
+                value: !include ../examples/errors.sample
             text/plain:
               example: |
                 "unable to delete <<resourcePathName|!singularize>> -- constraint violation"
@@ -66,7 +66,7 @@
             application/json:
               example:
                 strict: false
-                value: !include ../raml-util/examples/errors.sample
+                value: !include ../examples/errors.sample
             text/plain:
               example: "Internal server error, contact administrator"
 
@@ -88,7 +88,7 @@
             application/json:
               example:
                 strict: false
-                value: !include ../raml-util/examples/errors.sample
+                value: !include ../examples/errors.sample
             text/plain:
               example: |
                 "<<resourcePathName|!singularize>> not found"
@@ -98,7 +98,7 @@
             application/json:
               example:
                 strict: false
-                value: !include ../raml-util/examples/errors.sample
+                value: !include ../examples/errors.sample
             text/plain:
               example: |
                 "unable to update <<resourcePathName|!singularize>> -- malformed JSON at 13:4"
@@ -108,7 +108,7 @@
             application/json:
               example:
                 strict: false
-                value: !include ../raml-util/examples/errors.sample
+                value: !include ../examples/errors.sample
             text/plain:
               example: "internal server error, contact administrator"
 


### PR DESCRIPTION
[MODFIN-77](https://issues.folio.org/browse/MODFIN-77)
## Purpose
All Acquisition's business-modules can return errors in JSON format. So to avoid duplication we need a single place to store resource types supporting JSON-response.

## Approach
- adding collection and item-collection resource types with json response support.
