### PR TITLE
[MODINVOICE-100] Fix raml(contract) to return application/json respon…

### DIFF
--- a/rtypes/collection-get-with-json-response.raml
+++ b/rtypes/collection-get-with-json-response.raml
@@ -1,0 +1,56 @@
+#%RAML 1.0 ResourceType
+# collection-get.raml
+    description: Entity representing a <<resourcePathName|!singularize>>
+    is: [language]
+
+    get:
+      description: |
+        Retrieve <<resourcePathName|!singularize>> item with given {<<resourcePathName|!singularize>>Id}
+      responses:
+        200:
+          description: "Returns item with a given ID"
+          body:
+            application/json:
+              type: <<schemaCollection>>
+              example:
+                strict: false
+                value: <<exampleCollection>>
+        400:
+          description: "Bad request, e.g. malformed request body or query parameter. Details of the error (e.g. name of the parameter or line/character number with malformed data) provided in the response."
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../examples/errors.sample
+            text/plain:
+              example: |
+                "unable to list <<resourcePathName>> -- malformed parameter 'query', syntax error at column 6"
+        401:
+          description: "Not authorized to perform requested action"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../examples/errors.sample
+            text/plain:
+              example: |
+                "unable to list <<resourcePathName>> -- unauthorized"
+        404:
+          description: "Item with a given ID not found"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../examples/errors.sample
+            text/plain:
+              example: |
+                "<<resourcePathName|!singularize>> not found"
+        500:
+          description: "Internal server error, e.g. due to misconfiguration"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../examples/errors.sample
+            text/plain:
+              example: "internal server error, contact administrator"

--- a/rtypes/get-delete-with-json-response.raml
+++ b/rtypes/get-delete-with-json-response.raml
@@ -1,0 +1,81 @@
+
+    description: Entity representing a <<resourcePathName|!singularize>>
+    is: [language]
+
+    get:
+      description: |
+        Retrieve <<resourcePathName|!singularize>> item with given {<<resourcePathName|!singularize>>Id}
+      responses:
+        200:
+          description: "Returns item with a given ID"
+          body:
+            application/json:
+              type: <<schema>>
+              example:
+                strict: false
+                value: <<exampleItem>>
+        400:
+          description: "Bad request"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../examples/errors.sample
+            text/plain:
+              example: |
+                "unable to process <<resourcePathName|!singularize>> -- constraint violation"
+        404:
+          description: "Item with a given ID not found"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../examples/errors.sample
+            text/plain:
+              example: |
+                "<<resourcePathName|!singularize>> not found"
+        500:
+          description: "Internal server error, e.g. due to misconfiguration"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../examples/errors.sample
+            text/plain:
+              example: "internal server error, contact administrator"
+    delete:
+      description: |
+        Delete <<resourcePathName|!singularize>> item with given {<<resourcePathName|!singularize>>Id}
+      responses:
+        204:
+         description: "Item deleted successfully"
+        400:
+          description: "Bad request"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../examples/errors.sample
+            text/plain:
+              example: |
+                "unable to process <<resourcePathName|!singularize>> -- constraint violation"
+        404:
+          description: "Item with a given ID not found"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../examples/errors.sample
+            text/plain:
+              example: |
+                "<<resourcePathName|!singularize>> not found"
+        500:
+          description: "Internal server error, e.g. due to misconfiguration"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../examples/errors.sample
+            text/plain:
+              example: "Internal server error, contact administrator"
+

--- a/rtypes/get-only-with-json-response.raml
+++ b/rtypes/get-only-with-json-response.raml
@@ -1,0 +1,32 @@
+      description: Collection of <<resourcePathName|!singularize>> items.
+      is: [language]
+
+      get:
+        description: Retrieve a list of <<resourcePathName|!singularize>> items.
+        responses:
+          200:
+            description: "Returns a list of <<resourcePathName|!singularize>> items"
+            body:
+              application/json:
+                type: <<schema>>
+                example:
+                  strict: false
+                  value: <<exampleCollection>>
+          400:
+            description: "Bad request, e.g. malformed request body or query parameter. Details of the error (e.g. name of the parameter or line/character number with malformed data) provided in the response."
+            body:
+              application/json:
+                example:
+                  strict: false
+                  value: !include ../examples/errors.sample
+              text/plain:
+                example: "unable to list <<resourcePathName>> -- malformed parameter 'query', syntax error at column 6"
+          500:
+            description: "Internal server error, e.g. due to misconfiguration"
+            body:
+              application/json:
+                example:
+                  strict: false
+                  value: !include ../examples/errors.sample
+              text/plain:
+                example: "internal server error, contact administrator"

--- a/rtypes/item-collection-get-with-json-response.raml
+++ b/rtypes/item-collection-get-with-json-response.raml
@@ -1,0 +1,44 @@
+
+    description: Entity representing a <<resourcePathName|!singularize>>
+    is: [language]
+
+    get:
+      description: |
+        Retrieve <<resourcePathName|!singularize>> item with given {<<resourcePathName|!singularize>>Id}
+      responses:
+        200:
+          description: "Returns item with a given ID"
+          body:
+            application/json:
+              type: <<schema>>
+              example:
+                strict: false
+                value: <<exampleItem>>
+        401:
+          description: "Not authorized to perform requested action"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../examples/errors.sample
+            text/plain:
+              example: "unable to get retrieve <<resourcePathName|!singularize>> -- unauthorized"
+        404:
+          description: "Item with a given ID not found"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../examples/errors.sample
+            text/plain:
+              example: |
+                "<<resourcePathName|!singularize>> not found"
+        500:
+          description: "Internal server error, e.g. due to misconfiguration"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include ../examples/errors.sample
+            text/plain:
+              example: "internal server error, contact administrator"


### PR DESCRIPTION
## Purpose
All Acquisition's business-modules can return errors in JSON format. So to avoid duplication we need a single place to store resource types supporting JSON-response.
## Approach
Next items has been updated to return application/json for errors
- collection-get.raml
- get-delete.raml
- get-only.raml
- item-collection-get.raml
## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._

## Screenshots
_Let's see those sweet visuals!_
