### PR TITLE
Fix broken JSON codex example

### DIFF
--- a/examples/codex/packageCollection.sample
+++ b/examples/codex/packageCollection.sample
@@ -45,5 +45,6 @@
       "recordCount" : 1,
       "query" : "(name = a) sortby name"
     }
+  ]
   }
 }

--- a/examples/codex/packageCollection.sample
+++ b/examples/codex/packageCollection.sample
@@ -10,7 +10,10 @@
       "provider": "Gale|Cengage",
       "platform": "",
       "itemCount": 100,
-      "coverage":{"beginCoverage":"2018-08-13","endCoverage":"2018-09-13"},
+      "coverage": {
+        "beginCoverage": "2018-08-13",
+        "endCoverage": "2018-09-13"
+      },
       "isSelected": "Yes",
       "source": "ekb",
       "lastModified": "2019-02-11"
@@ -25,26 +28,31 @@
       "provider": "Gale|Cengage",
       "platform": "Gale|Cengage platform",
       "itemCount": 100,
-      "coverage":{"beginCoverage":"2018-08-13","endCoverage":"2018-09-13"},
+      "coverage": {
+        "beginCoverage": "2018-08-13",
+        "endCoverage": "2018-09-13"
+      },
       "isSelected": "NotSpecified",
       "source": "localkb",
       "lastModified": "2019-02-11"
     }
   ],
-  "resultInfo" : {
-    "totalRecords" : 2,
-    "facets" : [ ],
-    "diagnostics" : [ {
-      "source" : "mod-agreements-1.0.2",
-      "code" : "200",
-      "recordCount" : 1,
-      "query" : "(name = a) sortby name"
-    }, {
-      "source" : "mod-codex-ekb-1.1.0",
-      "code" : "200",
-      "recordCount" : 1,
-      "query" : "(name = a) sortby name"
-    }
-  ]
+  "resultInfo": {
+    "totalRecords": 2,
+    "facets": [],
+    "diagnostics": [
+      {
+        "source": "mod-agreements-1.0.2",
+        "code": "200",
+        "recordCount": 1,
+        "query": "(name = a) sortby name"
+      },
+      {
+        "source": "mod-codex-ekb-1.1.0",
+        "code": "200",
+        "recordCount": 1,
+        "query": "(name = a) sortby name"
+      }
+    ]
   }
 }


### PR DESCRIPTION
The parser behind the "lint-raml" facility seems to not process examples that are declared via the RAML resourceTypes.

However, the new AMF tools [FOLIO-2792](https://issues.folio.org/browse/FOLIO-2792) do.

Fixed basic JSON error.
