### PR TITLE
Allow 204 No Content wo Location for Tenant v2 FOLIO-2908

### DIFF
--- a/ramls/tenant.raml
+++ b/ramls/tenant.raml
@@ -15,6 +15,9 @@ types:
 /_/tenant:
   post:
     description: Create tenant job (create, upgrade, delete)
+      An implementation may choose to return 204 if the job is
+      completed by the initial operation; or it may return 201
+      and start the operation in the background.
     is: [validate,internal]
     body:
       application/json:
@@ -22,6 +25,8 @@ types:
         example:
           value: !include ../examples/tenantAttributes.sample
     responses:
+      204:
+        description: "Job completed"
       201:
         description: "Tenant job created"
         body:


### PR DESCRIPTION
## Purpose

Allow synchronous Tenant operation for Tenant v2. 

## Approach
The status 204 without Location indicates successful completed response.

## Note
RMB needs to be updated to use this.. So that implementations can choose to return 204 if they with to implement
the postTenant method of the Tenant interface