### PR TITLE
FOLIO-2926 FOLIO-2932 Use buildNode jenkins-agent-java11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
 
   agent {
     node {
-      label 'jenkins-slave-all'
+      label 'jenkins-agent-java11'
     }
   }
 


### PR DESCRIPTION
The old buildNode is deprecated. See [FOLIO-2926](https://issues.folio.org/browse/FOLIO-2926)
