### PR TITLE
Add HTTP response 409 as possible response for item-collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Shared RAML and schema files (raml-util)
 
-Copyright (C) 2016-2020 The Open Library Foundation
+Copyright (C) 2016-2021 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.

--- a/rtypes/item-collection.raml
+++ b/rtypes/item-collection.raml
@@ -74,6 +74,11 @@
             text/plain:
               example: |
                 "unable to update <<resourcePathName|!singularize>> -- malformed JSON at 13:4"
+        409:
+          description: "Conflict, constraint or optimistic locking failed"
+          body:
+            text/plain:
+              example: "optimistic locking failed"
         500:
           description: "Internal server error, e.g. due to misconfiguration"
           body:

--- a/rtypes/item-collection.raml
+++ b/rtypes/item-collection.raml
@@ -75,7 +75,7 @@
               example: |
                 "unable to update <<resourcePathName|!singularize>> -- malformed JSON at 13:4"
         409:
-          description: "Optimistic locking failed"
+          description: "Optimistic locking version conflict"
           body:
             text/plain:
               example: "version conflict"
@@ -84,4 +84,3 @@
           body:
             text/plain:
               example: "internal server error, contact administrator"
-

--- a/rtypes/item-collection.raml
+++ b/rtypes/item-collection.raml
@@ -75,10 +75,10 @@
               example: |
                 "unable to update <<resourcePathName|!singularize>> -- malformed JSON at 13:4"
         409:
-          description: "Conflict, constraint or optimistic locking failed"
+          description: "Optimistic locking failed"
           body:
             text/plain:
-              example: "optimistic locking failed"
+              example: "version conflict"
         500:
           description: "Internal server error, e.g. due to misconfiguration"
           body:


### PR DESCRIPTION
PUT on collections may return 409 due to optimistic locking failed. See https://issues.folio.org/browse/FOLIO-2993