### PR TITLE
FOLIO-2893 Use api-lint CI facility

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,12 @@ pipeline {
       }
     }
 
+    stage('API lint') {
+      steps {
+        runApiLint('RAML', 'ramls', 'ramls.raml jsonSchemas.raml')
+      }
+    }
+
     stage('Lint raml schema') {
       steps {
         runLintRamlSchema()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,12 +21,6 @@ pipeline {
       }
     }
 
-    stage('Lint raml-cop') {
-      steps {
-        runLintRamlCop()
-      }
-    }
-
     stage('API lint') {
       steps {
         runApiLint('RAML', 'ramls', 'ramls.raml jsonSchemas.raml')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,9 +33,9 @@ pipeline {
       }
     }
 
-    stage('Lint raml schema') {
+    stage('API schema lint') {
       steps {
-        runLintRamlSchema()
+        runApiSchemaLint('.', 'codex-next')
       }
     }
 

--- a/schemas/codex/codex_instance_cqlschema-ext.json
+++ b/schemas/codex/codex_instance_cqlschema-ext.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "name": "CODEX Instance CQL Schema Extended",
   "description": "Additional indexes and operators in CODEX instance search, support for them is optional. Indexes/relation that are not supported should be ignored by providers",
   "prefix": "ext",

--- a/schemas/codex/codex_instance_cqlschema.json
+++ b/schemas/codex/codex_instance_cqlschema.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "name": "CODEX Instance CQL Schema",
   "description": "Required indexes and operators in CODEX instance search. Providers should report any unsupported indexes/relations as errors.",
   "prefix": "codex",

--- a/schemas/codex/codex_package_cqlschema-ext.json
+++ b/schemas/codex/codex_package_cqlschema-ext.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "name": "CODEX Package CQL Schema Extended",
   "description": "Additional indexes and operators in CODEX package search, support for them is optional. Indexes/relation that are not supported should be ignored by providers",
   "prefix": "ext",

--- a/schemas/codex/codex_package_cqlschema.json
+++ b/schemas/codex/codex_package_cqlschema.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "name": "CODEX Package CQL Schema",
   "description": "Required indexes and operators in CODEX package search. Providers should report any unsupported indexes/relations as errors.",
   "prefix": "codex",


### PR DESCRIPTION
The doApiLint facility replaces runLintRamlCop

https://dev.folio.org/guides/api-lint/

