### PR TITLE
FOLIO-2898 Use api-doc CI facility

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
       }
     }
 
-    stage('Publish API Docs') {
+    stage('Generate API docs') {
       when {
         anyOf {
           branch 'master'
@@ -41,16 +41,9 @@ pipeline {
         }
       }
       steps {
-        sh 'python3 /usr/local/bin/generate_api_docs.py -r raml -l info -o folio-api-docs'
-        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding',
-                          accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-                          credentialsId: 'jenkins-aws',
-                          secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-          sh 'aws s3 sync folio-api-docs s3://foliodocs/api'
-        }
+        runApiDoc('RAML', 'ramls')
       }
     }
-
 
   } // end stages
 


### PR DESCRIPTION
The doApiDoc facility replaces publishAPI

https://dev.folio.org/guides/api-doc/
