### PR TITLE
FOLIO-2898 Fix api-doc CI facility

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
         }
       }
       steps {
-        runApiDoc('RAML', 'ramls')
+        runApiDoc('RAML', 'ramls', '')
       }
     }
 


### PR DESCRIPTION
Add missing apiExcludes argument. Required by this direct invocation even though empty at this stage.

