### PR TITLE
FOLIO-2993: 409 failed optimistic locking item-collection-with-json

### DIFF
--- a/rtypes/item-collection-with-json-response.raml
+++ b/rtypes/item-collection-with-json-response.raml
@@ -102,6 +102,11 @@
             text/plain:
               example: |
                 "unable to update <<resourcePathName|!singularize>> -- malformed JSON at 13:4"
+        409:
+          description: "Optimistic locking version conflict"
+          body:
+            text/plain:
+              example: "version conflict"
         500:
           description: "Internal server error, e.g. due to misconfiguration"
           body:


### PR DESCRIPTION
We also need to add a 409 HTTP response for PUT in rtypes/item-collection-with-json-response.raml