### PR TITLE
[FOLIO-3351] Remove "is: [language]" from rtypes

### DIFF
--- a/rtypes/collection-get-with-json-response.raml
+++ b/rtypes/collection-get-with-json-response.raml
@@ -1,7 +1,6 @@
 #%RAML 1.0 ResourceType
 # collection-get.raml
     description: Entity representing a <<resourcePathName|!singularize>>
-    is: [language]
 
     get:
       description: |

--- a/rtypes/collection-with-json-response.raml
+++ b/rtypes/collection-with-json-response.raml
@@ -6,7 +6,6 @@
 # - pageable:  !include traits/pageable.raml
 # - searchable: !include traits/searchable.raml
       description: Collection of <<resourcePathName|!singularize>> items.
-      is: [language]
 
       get:
         description: Retrieve a list of <<resourcePathName|!singularize>> items.

--- a/rtypes/get-delete-with-json-response.raml
+++ b/rtypes/get-delete-with-json-response.raml
@@ -1,6 +1,5 @@
 
     description: Entity representing a <<resourcePathName|!singularize>>
-    is: [language]
 
     get:
       description: |

--- a/rtypes/get-only-with-json-response.raml
+++ b/rtypes/get-only-with-json-response.raml
@@ -1,5 +1,4 @@
       description: Collection of <<resourcePathName|!singularize>> items.
-      is: [language]
 
       get:
         description: Retrieve a list of <<resourcePathName|!singularize>> items.

--- a/rtypes/item-collection-get-with-json-response.raml
+++ b/rtypes/item-collection-get-with-json-response.raml
@@ -1,6 +1,5 @@
 
     description: Entity representing a <<resourcePathName|!singularize>>
-    is: [language]
 
     get:
       description: |

--- a/rtypes/item-collection-with-json-response.raml
+++ b/rtypes/item-collection-with-json-response.raml
@@ -1,7 +1,6 @@
 #%RAML 1.0 ResourceType
 # item-collection-with-json-response.raml
     description: Entity representing a <<resourcePathName|!singularize>>
-    is: [language]
 
     get:
       description: |


### PR DESCRIPTION
## Purpose
Dependency to language file was delete because language file was delete before

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._

## Screenshots
_Let's see those sweet visuals!_
